### PR TITLE
fix: entity_name can be None

### DIFF
--- a/connect/api/v1/recent_activity/views.py
+++ b/connect/api/v1/recent_activity/views.py
@@ -50,14 +50,5 @@ class RecentActivityListAPIView(views.APIView):
             raise PermissionDenied()
 
         recent_activities = RecentActivity.objects.filter(project__uuid=project_uuid).order_by("-created_on")
-        data = []
-        for recent_activity in recent_activities:
-            data.append(
-                {
-                    "name": recent_activity.entity_name,
-                    "user": recent_activity.user_name,
-                    "created_at": recent_activity.created_on,
-                    "action": recent_activity.action_description_key
-                }
-            )
+        data = [recent_activity.to_json for recent_activity in recent_activities]
         return Response(status=status.HTTP_200_OK, data=data)

--- a/connect/common/models.py
+++ b/connect/common/models.py
@@ -1875,3 +1875,14 @@ class RecentActivity(models.Model):
 
         return self.user.email
 
+    @property
+    def to_json(self):
+        data = {
+            "user": self.user_name,
+            "created_at": self.created_on,
+            "action": self.action_description_key
+        }
+        if self.entity_name:
+            data.update({"name": self.entity_name })
+        
+        return data


### PR DESCRIPTION
on recent activities list api if is a trigger don't pass the entity_name field