### PR TITLE
Feature/return trial period

### DIFF
--- a/connect/api/v1/organization/serializers.py
+++ b/connect/api/v1/organization/serializers.py
@@ -43,7 +43,8 @@ class BillingPlanSerializer(serializers.ModelSerializer):
             "problem_capture_invoice",
             "currenty_invoice",
             "contract_on",
-            "trial_end_date"
+            "trial_end_date",
+            "days_till_trial_end"
         ]
         ref_name = None
 

--- a/connect/api/v2/user/views.py
+++ b/connect/api/v2/user/views.py
@@ -1,12 +1,11 @@
-from rest_framework import views, status
-from django.conf import settings
+from rest_framework import views
 from django.http import JsonResponse
-from connect.api.v1.internal.permissions import ModuleHasPermission
 from connect.api.v1.internal.flows.flows_rest_client import FlowsRESTClient
 from connect.common.models import Project
 
+
 class UserAPIToken(views.APIView):
-    
+
     def get(self, request, *args, **kwargs):
         project_uuid = kwargs.get("project_uuid")
         user = request.query_params.get("user")

--- a/connect/common/models.py
+++ b/connect/common/models.py
@@ -1713,6 +1713,13 @@ class BillingPlan(models.Model):
                 name="update_suspend_project", args=[project.flow_organization, True]
             )
 
+    @property
+    def days_till_trial_end(self):
+        if self.plan == BillingPlan.PLAN_TRIAL:
+            today = pendulum.now()
+            trial_end = pendulum.instance(self.trial_end_date)
+            return today.diff(trial_end, False).in_days()
+
 
 class Invoice(models.Model):
     class Meta:

--- a/connect/common/tests/tests.py
+++ b/connect/common/tests/tests.py
@@ -22,6 +22,7 @@ from connect.common.models import (
 )
 from django.conf import settings
 from connect.common.gateways.rocket_gateway import Rocket
+from freezegun import freeze_time
 
 
 class NewsletterTestCase(TestCase):
@@ -478,6 +479,21 @@ class OrganizationTestCase(TestCase):
         self.assertEqual(outbox.subject, "A new permission has been assigned to you")
         self.assertEqual(outbox.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(outbox.to[0], self.test_email)
+
+    def test_days_till_trial_end(self):
+        organization = Organization.objects.create(
+            name="Test Organization Trial",
+            inteligence_organization=0,
+            organization_billing__cycle=BillingPlan.BILLING_CYCLE_MONTHLY,
+            organization_billing__plan=BillingPlan.PLAN_TRIAL,
+        )
+        
+        today = pendulum.now()
+
+        with freeze_time(today.add(months=1)):
+            print(organization.organization_billing.days_till_trial_end)
+            self.assertEquals(organization.organization_billing.days_till_trial_end, 0)
+
 
 
 class BillingPlanTestCase(TestCase):

--- a/connect/common/tests/tests.py
+++ b/connect/common/tests/tests.py
@@ -487,13 +487,11 @@ class OrganizationTestCase(TestCase):
             organization_billing__cycle=BillingPlan.BILLING_CYCLE_MONTHLY,
             organization_billing__plan=BillingPlan.PLAN_TRIAL,
         )
-        
         today = pendulum.now()
 
         with freeze_time(today.add(months=1)):
             print(organization.organization_billing.days_till_trial_end)
             self.assertEquals(organization.organization_billing.days_till_trial_end, 0)
-
 
 
 class BillingPlanTestCase(TestCase):


### PR DESCRIPTION
Add:
- Return the remaining days till the end of the trial period in the `GET` organization endpoint