### PR TITLE
Add select related to the org's authorization list to improve endpoint performance

### DIFF
--- a/connect/api/v1/organization/serializers.py
+++ b/connect/api/v1/organization/serializers.py
@@ -216,13 +216,13 @@ class OrganizationSeralizer(serializers.HyperlinkedModelSerializer):
             "count": obj.authorizations.count(),
             "users": [
                 {
-                    "username": i.user.username,
-                    "first_name": i.user.first_name,
-                    "last_name": i.user.last_name,
-                    "role": i.role,
-                    "photo_user": i.user.photo_url,
+                    "username": authoirization.user.username,
+                    "first_name": authoirization.user.first_name,
+                    "last_name": authoirization.user.last_name,
+                    "role": authoirization.role,
+                    "photo_user": authoirization.user.photo_url,
                 }
-                for i in obj.authorizations.select_related("user").exclude(role__in=exclude_roles)
+                for authoirization in obj.authorizations.select_related("user").exclude(role__in=exclude_roles)
             ],
         }
 

--- a/connect/api/v1/organization/serializers.py
+++ b/connect/api/v1/organization/serializers.py
@@ -222,7 +222,7 @@ class OrganizationSeralizer(serializers.HyperlinkedModelSerializer):
                     "role": i.role,
                     "photo_user": i.user.photo_url,
                 }
-                for i in obj.authorizations.exclude(role__in=exclude_roles)
+                for i in obj.authorizations.select_related("user").exclude(role__in=exclude_roles)
             ],
         }
 


### PR DESCRIPTION
The objective of this PR is to improve performance on the org listing screen.
Based on tests I did locally I was able to see an improvement of `1417 ms`, but this may vary up or down depending on the user.

- **Before**
![image](https://github.com/weni-ai/weni-engine/assets/49874732/ca78aff0-dd7f-4f3b-9125-02cb948fb4f1)

- **After**
![image](https://github.com/weni-ai/weni-engine/assets/49874732/391b42bb-02f1-4a6c-b075-cfc2d3e0c4f2)
