### PR TITLE
Fix/organization name field length validation

### DIFF
--- a/connect/api/v2/organizations/tests.py
+++ b/connect/api/v2/organizations/tests.py
@@ -223,7 +223,7 @@ class OrganizationViewSetTestCase(TestCase):
         response, content_data = self.request(path, method, user=user, data=data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data["name"][0].code, "max_length")
+        self.assertEqual(response.data["organization"]["name"][0].code, "max_length")
 
     @patch("connect.internals.event_driven.producer.rabbitmq_publisher.RabbitmqPublisher.send_message")
     @patch("connect.authentication.models.User.send_request_flow_user_info")

--- a/connect/api/v2/organizations/tests.py
+++ b/connect/api/v2/organizations/tests.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from django.test import TestCase
-from django.utils import get_random_string
+from django.utils.crypto import get_random_string
 
 from unittest.mock import patch
 

--- a/connect/api/v2/organizations/views.py
+++ b/connect/api/v2/organizations/views.py
@@ -83,7 +83,7 @@ class OrganizationViewSet(
 
         # Organization
         serializer = self.get_serializer(data=org_data)
-        serializer.is_valid()
+        serializer.is_valid(raise_exception=True)
         instance = serializer.save()
 
         if type(instance) == dict:
@@ -94,7 +94,7 @@ class OrganizationViewSet(
             {"organization": instance.uuid}
         )
         project_serializer = ProjectSerializer(data=project_data, context={"request": request})
-        project_serializer.is_valid()
+        project_serializer.is_valid(raise_exception=True)
         project_instance = project_serializer.save()
 
         if type(project_instance) == dict:

--- a/connect/api/v2/organizations/views.py
+++ b/connect/api/v2/organizations/views.py
@@ -1,5 +1,5 @@
 import pendulum
-from rest_framework import mixins, status
+from rest_framework import mixins, status, exceptions
 from rest_framework.decorators import action
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.response import Response
@@ -83,7 +83,12 @@ class OrganizationViewSet(
 
         # Organization
         serializer = self.get_serializer(data=org_data)
-        serializer.is_valid(raise_exception=True)
+
+        try:
+            serializer.is_valid(raise_exception=True)
+        except exceptions.ValidationError as e:
+            raise exceptions.ValidationError({"organization": e.detail}, code=e.get_codes())
+
         instance = serializer.save()
 
         if type(instance) == dict:
@@ -94,7 +99,12 @@ class OrganizationViewSet(
             {"organization": instance.uuid}
         )
         project_serializer = ProjectSerializer(data=project_data, context={"request": request})
-        project_serializer.is_valid(raise_exception=True)
+
+        try:
+            project_serializer.is_valid(raise_exception=True)
+        except exceptions.ValidationError as e:
+            raise exceptions.ValidationError({"project": e.detail}, code=e.get_codes())
+
         project_instance = project_serializer.save()
 
         if type(project_instance) == dict:

--- a/connect/api/v2/projects/serializers.py
+++ b/connect/api/v2/projects/serializers.py
@@ -60,7 +60,7 @@ class ProjectSerializer(serializers.ModelSerializer):
         ref_name = None
 
     uuid = serializers.UUIDField(style={"show": False}, read_only=True)
-    name = serializers.CharField(max_length=500, required=True)
+    name = serializers.CharField(max_length=150, required=True)
     description = serializers.CharField(max_length=1000, required=False)
     organization = serializers.PrimaryKeyRelatedField(
         queryset=Organization.objects,


### PR DESCRIPTION
## What
Add a raise_exception=True parameter to the organization and project serializers in the OrganizationViewSet.create method (POST /v2/organizations/).

## Why
Currently, when raise_exception=False (the default behavior), a generic 500 server error is returned without providing meaningful details about what went wrong with the request.