### PR TITLE
feat: Validate project type change

### DIFF
--- a/connect/api/v2/projects/tests.py
+++ b/connect/api/v2/projects/tests.py
@@ -230,6 +230,31 @@ class ProjectViewSetTestCase(TestCase):
 
         path = f"/v2/projects/{project_uuid}/set-type"
         method = {"post": "set_type"}
+        data = {"project_type": TypeProject.GENERAL}
+        user = self.user
+
+        response, content_data = self.request(
+            path,
+            method,
+            user=user,
+            project_uuid=project_uuid,
+            data=data,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(content_data.get("project_type"), TypeProject.GENERAL)
+
+        self.project1.refresh_from_db()
+        self.assertEqual(self.project1.project_type, TypeProject.GENERAL)
+
+    def test_cannot_set_type_to_commerce_once_is_general(self):
+        """Test successfully setting a valid project type"""
+        self.project1.project_type = TypeProject.GENERAL
+        self.project1.save()
+        project_uuid = str(self.project1.uuid)
+
+        path = f"/v2/projects/{project_uuid}/set-type"
+        method = {"post": "set_type"}
         data = {"project_type": TypeProject.COMMERCE}
         user = self.user
 
@@ -241,11 +266,14 @@ class ProjectViewSetTestCase(TestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(content_data.get("project_type"), TypeProject.COMMERCE)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            f"It is not possible to change the type from {TypeProject.GENERAL} to {TypeProject.COMMERCE}",
+            content_data.get("detail"),
+        )
 
         self.project1.refresh_from_db()
-        self.assertEquals(self.project1.project_type, TypeProject.COMMERCE)
+        self.assertNotEqual(self.project1.project_type, TypeProject.COMMERCE)
 
     def test_set_type_invalid_type(self):
         """Test setting an invalid project type returns error"""

--- a/connect/api/v2/projects/views.py
+++ b/connect/api/v2/projects/views.py
@@ -1,4 +1,5 @@
 from rest_framework import mixins, status
+from rest_framework.exceptions import ValidationError
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.response import Response
 from rest_framework.decorators import action
@@ -116,7 +117,7 @@ class ProjectViewSet(
 
     @action(detail=True, methods=["POST"], url_name="set-type")
     def set_type(self, request, **kwargs):
-        instance = self.get_object()
+        instance: Project = self.get_object()
         try:
             project_type = request.data.get("project_type")
 
@@ -126,6 +127,17 @@ class ProjectViewSet(
                     choices_text.append(f"{value} ({label.title()})")
                 return Response(
                     {"detail": f"Invalid type. Choices are: {', '.join(choices_text)}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if (
+                instance.project_type == TypeProject.GENERAL
+                and project_type == TypeProject.COMMERCE
+            ):
+                return Response(
+                    {
+                        "detail": f"It is not possible to change the type from {TypeProject.GENERAL} to {TypeProject.COMMERCE}"
+                    },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 

--- a/connect/api/v2/projects/views.py
+++ b/connect/api/v2/projects/views.py
@@ -1,5 +1,4 @@
 from rest_framework import mixins, status
-from rest_framework.exceptions import ValidationError
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.response import Response
 from rest_framework.decorators import action


### PR DESCRIPTION
### What
Adds validation to prevent a general type project from having its type set to commerce.

### Why
This is done to prevent a downgrade from the extended mode. 