### PR TITLE
Feature: Add CRM Organizations API endpoint

### DIFF
--- a/connect/api/tests/decorators.py
+++ b/connect/api/tests/decorators.py
@@ -1,6 +1,11 @@
 import functools
 
-from connect.common.models import OrganizationAuthorization, OrganizationRole, ProjectAuthorization, ProjectRole
+from connect.common.models import (
+    OrganizationAuthorization,
+    OrganizationRole,
+    ProjectAuthorization,
+    ProjectRole,
+)
 
 
 def with_project_auth(role=ProjectRole.NOT_SETTED.value):
@@ -10,12 +15,20 @@ def with_project_auth(role=ProjectRole.NOT_SETTED.value):
             project = self.project
             user = self.user
 
-            organization_authorization = OrganizationAuthorization.objects.filter(organization=project.organization, user=user).first()
-            ProjectAuthorization.objects.create(project=project, user=user, role=role, organization_authorization=organization_authorization)
+            organization_authorization = OrganizationAuthorization.objects.filter(
+                organization=project.organization, user=user
+            ).first()
+            ProjectAuthorization.objects.create(
+                project=project,
+                user=user,
+                role=role,
+                organization_authorization=organization_authorization,
+            )
 
             return func(self, *args, **kwargs)
 
         return wrapper
+
     return decorator
 
 
@@ -26,9 +39,12 @@ def with_organization_auth(role=OrganizationRole.NOT_SETTED.value):
             organization = self.organization
             user = self.user
 
-            OrganizationAuthorization.objects.create(organization=organization, user=user, role=role)
+            OrganizationAuthorization.objects.create(
+                organization=organization, user=user, role=role
+            )
 
             return func(self, *args, **kwargs)
 
         return wrapper
+
     return decorator

--- a/connect/api/v1/organization/serializers.py
+++ b/connect/api/v1/organization/serializers.py
@@ -162,7 +162,9 @@ class OrganizationSeralizer(serializers.HyperlinkedModelSerializer):
     def validate_description(self, value):
         stripped_value = strip_tags(value)
         if not stripped_value.strip():
-            raise ValidationError(_("Description cannot be empty or contain only HTML tags"))
+            raise ValidationError(
+                _("Description cannot be empty or contain only HTML tags")
+            )
         return stripped_value
 
     def create_organization(self, validated_data):  # pragma: no cover

--- a/connect/api/v1/project/views.py
+++ b/connect/api/v1/project/views.py
@@ -23,31 +23,50 @@ from connect.api.v1.internal.permissions import ModuleHasPermission
 from connect.api.v1.metadata import Metadata
 from connect.api.v1.organization.permissions import Has2FA
 from connect.api.v1.project.filters import ProjectOrgFilter
-from connect.api.v1.project.permissions import CanChangeProjectStatus, ProjectHasPermission
+from connect.api.v1.project.permissions import (
+    CanChangeProjectStatus,
+    ProjectHasPermission,
+)
 from connect.api.v1.project.serializers import (
-    ClassifierSerializer, CreateChannelSerializer, CreateClassifierSerializer,
-    CreateWACChannelSerializer, DestroyClassifierSerializer,
-    ProjectSearchSerializer, ProjectSerializer, ReleaseChannelSerializer,
-    RequestPermissionProjectSerializer, RequestRocketPermissionSerializer,
-    RetrieveClassifierSerializer, TemplateProjectSerializer, UpdateProjectStatusSerializer,
-    UserAPITokenSerializer)
+    ClassifierSerializer,
+    CreateChannelSerializer,
+    CreateClassifierSerializer,
+    CreateWACChannelSerializer,
+    DestroyClassifierSerializer,
+    ProjectSearchSerializer,
+    ProjectSerializer,
+    ReleaseChannelSerializer,
+    RequestPermissionProjectSerializer,
+    RequestRocketPermissionSerializer,
+    RetrieveClassifierSerializer,
+    TemplateProjectSerializer,
+    UpdateProjectStatusSerializer,
+    UserAPITokenSerializer,
+)
 from connect.authentication.models import User
 from connect.billing.models import Contact
 from connect.celery import app as celery_app
 from connect.common import tasks
-from connect.common.models import (OpenedProject, Organization,
-                                   OrganizationAuthorization, Project,
-                                   ProjectAuthorization,
-                                   RequestPermissionProject,
-                                   RequestRocketPermission, TemplateProject)
-from connect.internals.event_driven.producer.rabbitmq_publisher import \
-    RabbitmqPublisher
+from connect.common.models import (
+    OpenedProject,
+    Organization,
+    OrganizationAuthorization,
+    Project,
+    ProjectAuthorization,
+    RequestPermissionProject,
+    RequestRocketPermission,
+    TemplateProject,
+)
+from connect.internals.event_driven.producer.rabbitmq_publisher import RabbitmqPublisher
 from connect.usecases.authorizations.create import CreateAuthorizationUseCase
 from connect.usecases.authorizations.delete import DeleteAuthorizationUseCase
-from connect.usecases.authorizations.dto import (CreateProjectAuthorizationDTO,
-                                                 DeleteProjectAuthorizationDTO)
-from connect.usecases.authorizations.exceptions import \
-    UserHasNoPermissionToManageProject
+from connect.usecases.authorizations.dto import (
+    CreateProjectAuthorizationDTO,
+    DeleteProjectAuthorizationDTO,
+)
+from connect.usecases.authorizations.exceptions import (
+    UserHasNoPermissionToManageProject,
+)
 from connect.utils import count_contacts, rate_limit
 
 logger = logging.getLogger(__name__)
@@ -446,7 +465,11 @@ class RequestPermissionProjectViewSet(
     permission_classes = [IsAuthenticated]
     metadata_class = Metadata
 
-    @rate_limit(requests=settings.RATE_LIMIT_REQUESTS, window=settings.RATE_LIMIT_WINDOW, block_time=settings.RATE_LIMIT_BLOCK_TIME)
+    @rate_limit(
+        requests=settings.RATE_LIMIT_REQUESTS,
+        window=settings.RATE_LIMIT_WINDOW,
+        block_time=settings.RATE_LIMIT_BLOCK_TIME,
+    )
     def create(self, request, *args, **kwargs):
         created_by: User = self.request.user
         role: int = int(self.request.data.get("role"))

--- a/connect/api/v1/tests/test_project.py
+++ b/connect/api/v1/tests/test_project.py
@@ -487,7 +487,9 @@ class BaseUpdateProjectStatusTestCase(APITestCase):
 
 class TestUpdateProjectStatusAnonymousUser(BaseUpdateProjectStatusTestCase):
     def test_cannot_update_project_status(self):
-        response = self.update_project_status(self.project, {"status": ProjectStatus.INACTIVE.value})
+        response = self.update_project_status(
+            self.project, {"status": ProjectStatus.INACTIVE.value}
+        )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
@@ -501,21 +503,27 @@ class TestUpdateProjectStatusAuthenticatedUser(BaseUpdateProjectStatusTestCase):
         self.client.force_authenticate(user=self.user)
 
     def test_cannot_update_project_status_without_permission(self):
-        response = self.update_project_status(self.project, {"status": ProjectStatus.INACTIVE.value})
+        response = self.update_project_status(
+            self.project, {"status": ProjectStatus.INACTIVE.value}
+        )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @with_organization_auth(role=OrganizationRole.VIEWER.value)
     @with_project_auth(role=ProjectRole.VIEWER.value)
     def test_cannot_update_project_status_as_viewer(self):
-        response = self.update_project_status(self.project, {"status": ProjectStatus.INACTIVE.value})
+        response = self.update_project_status(
+            self.project, {"status": ProjectStatus.INACTIVE.value}
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @with_organization_auth(role=OrganizationRole.CONTRIBUTOR.value)
     @with_project_auth(role=ProjectRole.CONTRIBUTOR.value)
     def test_update_project_status_as_contributor(self):
-        response = self.update_project_status(self.project, {"status": ProjectStatus.INACTIVE.value})
+        response = self.update_project_status(
+            self.project, {"status": ProjectStatus.INACTIVE.value}
+        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -525,7 +533,9 @@ class TestUpdateProjectStatusAuthenticatedUser(BaseUpdateProjectStatusTestCase):
     @with_organization_auth(role=OrganizationRole.SUPPORT.value)
     @with_project_auth(role=ProjectRole.SUPPORT.value)
     def test_cannot_update_project_status_as_support(self):
-        response = self.update_project_status(self.project, {"status": ProjectStatus.INACTIVE.value})
+        response = self.update_project_status(
+            self.project, {"status": ProjectStatus.INACTIVE.value}
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 

--- a/connect/api/v2/internals/filters.py
+++ b/connect/api/v2/internals/filters.py
@@ -1,0 +1,84 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils.translation import ugettext_lazy as _
+from django_filters import rest_framework as filters
+from rest_framework.exceptions import NotFound
+
+from connect.common.models import Organization, Project
+
+
+class CRMOrganizationFilter(filters.FilterSet):
+    """Filter class for CRM Organization endpoint with comprehensive filtering"""
+
+    class Meta:
+        model = Organization
+        fields = []
+
+    organization_uuid = filters.UUIDFilter(
+        field_name="uuid",
+        help_text=_("Filter by specific organization UUID"),
+    )
+
+    project_uuid = filters.UUIDFilter(
+        method="filter_by_project_uuid",
+        help_text=_(
+            "Filter by project UUID - returns only the organization containing that project"
+        ),
+    )
+
+    has_vtex_account = filters.BooleanFilter(
+        method="filter_has_vtex_account",
+        help_text=_(
+            "Filter organizations that have projects with vtex_account (true/false)"
+        ),
+    )
+
+    created_after = filters.DateFilter(
+        field_name="created_at",
+        lookup_expr="gte",
+        help_text=_("Organizations created after this date (format: DD-MM-YYYY)"),
+        input_formats=["%d-%m-%Y"],
+    )
+
+    created_before = filters.DateFilter(
+        field_name="created_at",
+        lookup_expr="lte",
+        help_text=_("Organizations created before this date (format: DD-MM-YYYY)"),
+        input_formats=["%d-%m-%Y"],
+    )
+
+    def filter_by_project_uuid(self, queryset, name, value):
+        """
+        Special filter logic: When filtering by project UUID, return only the
+        organization containing that project. The serializer will handle showing
+        only that specific project in the projects list.
+        """
+        try:
+            project = Project.objects.get(uuid=value)
+            self.request.filtered_project_uuid = value
+            return queryset.filter(uuid=project.organization.uuid)
+        except Project.DoesNotExist:
+            raise NotFound(_("Project {} does not exist").format(value))
+        except DjangoValidationError:
+            raise NotFound(_("Invalid project UUID"))
+
+    def filter_has_vtex_account(self, queryset, name, value):
+        """
+        Filter organizations based on whether they have projects with vtex_account
+        true: organizations with at least one project having vtex_account
+        false: organizations with no projects having vtex_account
+        """
+        if value is True:
+            return queryset.filter(
+                project__vtex_account__isnull=False, project__vtex_account__gt=""
+            ).distinct()
+        elif value is False:
+            organizations_with_vtex = (
+                Organization.objects.filter(
+                    project__vtex_account__isnull=False, project__vtex_account__gt=""
+                )
+                .distinct()
+                .values_list("uuid", flat=True)
+            )
+            return queryset.exclude(uuid__in=organizations_with_vtex)
+
+        return queryset

--- a/connect/api/v2/internals/serializers.py
+++ b/connect/api/v2/internals/serializers.py
@@ -12,7 +12,6 @@ from connect.common.models import (
     RequestPermissionOrganization,
     OrganizationLevelRole,
     OrganizationRole,
-    ProjectRole,
     Project,
 )
 

--- a/connect/api/v2/internals/serializers.py
+++ b/connect/api/v2/internals/serializers.py
@@ -12,6 +12,7 @@ from connect.common.models import (
     RequestPermissionOrganization,
     OrganizationLevelRole,
     OrganizationRole,
+    ProjectRole,
     Project,
 )
 
@@ -164,3 +165,78 @@ class RequestPermissionOrganizationSerializer(serializers.ModelSerializer):
             )
 
         return user_data
+
+
+# CRM Serializers for the new CRM Organizations endpoint
+
+
+class CRMUserSerializer(serializers.ModelSerializer):
+    """Serializer for user data in CRM responses"""
+
+    class Meta:
+        model = User
+        fields = ["email", "first_name", "last_name", "role", "role_name"]
+
+    role = serializers.SerializerMethodField()
+    role_name = serializers.SerializerMethodField()
+
+    def get_role(self, obj):
+        """Get role from the authorization context"""
+        authorization = getattr(obj, "_authorization", None)
+        return authorization.role if authorization else None
+
+    def get_role_name(self, obj):
+        """Get human-readable role name"""
+        authorization = getattr(obj, "_authorization", None)
+        if authorization:
+            if hasattr(authorization, "role_verbose"):
+                return authorization.role_verbose
+            # Fallback to choices lookup
+            role_choices = dict(authorization.ROLE_CHOICES)
+            return role_choices.get(authorization.role, "unknown")
+        return None
+
+
+class CRMProjectSerializer(serializers.ModelSerializer):
+    """Serializer for project data in CRM responses"""
+
+    class Meta:
+        model = Project
+        fields = ["name", "uuid", "vtex_account"]
+
+
+class CRMOrganizationSerializer(serializers.ModelSerializer):
+    """Main serializer for CRM Organization responses"""
+
+    class Meta:
+        model = Organization
+        fields = ["uuid", "name", "created_at", "users", "projects"]
+
+    users = serializers.SerializerMethodField()
+    projects = serializers.SerializerMethodField()
+
+    def get_users(self, obj):
+        """Get organization users excluding NOT_SETTED roles"""
+        org_authorizations = obj.authorizations.exclude(
+            role=OrganizationRole.NOT_SETTED.value
+        ).select_related("user")
+
+        users = []
+        for auth in org_authorizations:
+            auth.user._authorization = auth
+            users.append(auth.user)
+
+        return CRMUserSerializer(users, many=True).data
+
+    def get_projects(self, obj):
+        """Get organization projects, with special handling for project_uuid filter"""
+        request = self.context.get("request")
+
+        filtered_project_uuid = getattr(request, "filtered_project_uuid", None)
+
+        if filtered_project_uuid:
+            projects = obj.project.filter(uuid=filtered_project_uuid)
+        else:
+            projects = obj.project.all()
+
+        return CRMProjectSerializer(projects, many=True).data

--- a/connect/api/v2/internals/test_crm_organizations.py
+++ b/connect/api/v2/internals/test_crm_organizations.py
@@ -1,0 +1,322 @@
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import patch, Mock
+
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+from connect.api.v1.tests.utils import create_user_and_token
+from connect.common.models import (
+    Organization,
+    OrganizationAuthorization,
+    Project,
+    ProjectAuthorization,
+    ProjectRole,
+    OrganizationRole,
+    BillingPlan,
+    TypeProject,
+)
+from connect.common.mocks import StripeMockGateway
+
+
+@override_settings(USE_EDA_PERMISSIONS=False)
+class CRMOrganizationViewSetTestCase(APITestCase):
+
+    @patch("connect.authentication.signals.RabbitmqPublisher")
+    @patch("connect.common.signals.RabbitmqPublisher")
+    @patch("connect.common.signals.update_user_permission_project")
+    @patch("connect.billing.get_gateway")
+    def setUp(self, mock_get_gateway, mock_permission, mock_rabbitmq_common, mock_rabbitmq_auth):
+        mock_get_gateway.return_value = StripeMockGateway()
+        mock_permission.return_value = True
+        mock_rabbitmq_common.return_value = Mock()
+        mock_rabbitmq_auth.return_value = Mock()
+
+        self.client = APIClient()
+        self.crm_user, self.crm_token = create_user_and_token("crmuser")
+        self.regular_user, self.regular_token = create_user_and_token("regularuser")
+
+        # Create test organizations
+        self.org1 = self._create_org("Test Organization 1", days_ago=10)
+        self.org2 = self._create_org("Test Organization 2", days_ago=5)
+        self.org3 = self._create_org("Test Organization 3", days_ago=1)
+
+        self.project1 = self._create_project("Project 1", self.org1, "vtex-account-1", TypeProject.COMMERCE)
+        self.project2 = self._create_project("Project 2", self.org1, "", TypeProject.GENERAL)
+        self.project3 = self._create_project("Project 3", self.org2, "vtex-account-2", TypeProject.COMMERCE)
+        self.project4 = self._create_project("Project 4", self.org3, None, TypeProject.GENERAL)
+
+        self._create_auth_data()
+        self.list_url = reverse("crm-organizations-list")
+
+    def _create_org(self, name, days_ago):
+        return Organization.objects.create(
+            name=name,
+            description=f"{name} description",
+            organization_billing__cycle=BillingPlan.BILLING_CYCLE_MONTHLY,
+            organization_billing__plan=BillingPlan.PLAN_TRIAL,
+            created_at=datetime.now() - timedelta(days=days_ago),
+        )
+
+    def _create_project(self, name, org, vtex_account, project_type):
+        kwargs = {"name": name, "organization": org, "flow_organization": uuid.uuid4(), "project_type": project_type}
+        if vtex_account is not None:
+            kwargs["vtex_account"] = vtex_account
+        return Project.objects.create(**kwargs)
+
+    def _create_auth_data(self):
+        self.org1_auth = OrganizationAuthorization.objects.create(
+            user=self.crm_user, organization=self.org1, role=OrganizationRole.ADMIN.value
+        )
+        self.org1_auth_regular = OrganizationAuthorization.objects.create(
+            user=self.regular_user, organization=self.org1, role=OrganizationRole.VIEWER.value
+        )
+        OrganizationAuthorization.objects.create(
+            user=self.regular_user, organization=self.org2, role=OrganizationRole.NOT_SETTED.value
+        )
+        self.org2_auth = OrganizationAuthorization.objects.create(
+            user=self.crm_user, organization=self.org2, role=OrganizationRole.CONTRIBUTOR.value
+        )
+
+        ProjectAuthorization.objects.create(
+            user=self.crm_user, project=self.project1, role=ProjectRole.MODERATOR.value,
+            organization_authorization=self.org1_auth
+        )
+        ProjectAuthorization.objects.create(
+            user=self.regular_user, project=self.project1, role=ProjectRole.NOT_SETTED.value,
+            organization_authorization=self.org1_auth_regular
+        )
+        ProjectAuthorization.objects.create(
+            user=self.crm_user, project=self.project3, role=ProjectRole.CONTRIBUTOR.value,
+            organization_authorization=self.org2_auth
+        )
+
+    def _auth_as_crm(self):
+        self.client.force_authenticate(user=self.crm_user)
+
+    # Permission Tests
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_crm_user_can_access(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_non_crm_user_forbidden(self):
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @override_settings(ALLOW_CRM_ACCESS=False, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_crm_access_disabled(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_user_denied(self):
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # Structure Tests
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_response_structure(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        for field in ["next", "previous", "results"]:
+            self.assertIn(field, response.data)
+        
+        results = response.data["results"]
+        self.assertGreater(len(results), 0)
+        
+        org = results[0]
+        for field in ["uuid", "name", "created_at", "users", "projects"]:
+            self.assertIn(field, org)
+        
+        if org["users"]:
+            user = org["users"][0]
+            for field in ["email", "first_name", "last_name", "role", "role_name"]:
+                self.assertIn(field, user)
+        
+        if org["projects"]:
+            project = org["projects"][0]
+            for field in ["name", "uuid", "vtex_account"]:
+                self.assertIn(field, project)
+            self.assertNotIn("users", project)
+
+    # Filter Tests
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_filter_by_organization_uuid(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"organization_uuid": str(self.org1.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["uuid"], str(self.org1.uuid))
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_filter_by_project_uuid_special_logic(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"project_uuid": str(self.project1.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["uuid"], str(self.org1.uuid))
+        
+        projects = results[0]["projects"]
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0]["uuid"], str(self.project1.uuid))
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_filter_project_uuid_not_found(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"project_uuid": str(uuid.uuid4())})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_filter_project_uuid_invalid_format(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"project_uuid": "invalid-uuid"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_filter_has_vtex_account_true(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"has_vtex_account": "true"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        
+        org_uuids = [org["uuid"] for org in results]
+        self.assertIn(str(self.org1.uuid), org_uuids)
+        self.assertIn(str(self.org2.uuid), org_uuids)
+        self.assertNotIn(str(self.org3.uuid), org_uuids)
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_filter_has_vtex_account_false(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"has_vtex_account": "false"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        
+        org_uuids = [org["uuid"] for org in results]
+        self.assertIn(str(self.org3.uuid), org_uuids)
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_filter_by_date_range(self):
+        self._auth_as_crm()
+        yesterday = (datetime.now() - timedelta(days=2)).strftime("%d-%m-%Y")
+        response = self.client.get(self.list_url, {"created_after": yesterday})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        
+        org_uuids = [org["uuid"] for org in results]
+        self.assertIn(str(self.org3.uuid), org_uuids)
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_filter_invalid_date_format(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"created_after": "2024-01-15"})
+        self.assertIn(response.status_code, [status.HTTP_400_BAD_REQUEST, status.HTTP_200_OK])
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_combined_filters(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {
+            "has_vtex_account": "true",
+            "organization_uuid": str(self.org1.uuid)
+        })
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["uuid"], str(self.org1.uuid))
+
+    # Data Validation Tests
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_exclude_not_setted_roles(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"organization_uuid": str(self.org1.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        
+        org = results[0]
+        users = org["users"]
+        user_emails = [user["email"] for user in users]
+        self.assertIn("crmuser@user.com", user_emails)
+        self.assertIn("regularuser@user.com", user_emails)
+        
+        for user in users:
+            self.assertNotEqual(user["role"], OrganizationRole.NOT_SETTED.value)
+            self.assertIsNotNone(user["role_name"])
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_retrieve_specific_organization(self):
+        self._auth_as_crm()
+        detail_url = reverse("crm-organizations-detail", kwargs={"uuid": self.org1.uuid})
+        response = self.client.get(detail_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        self.assertEqual(response.data["uuid"], str(self.org1.uuid))
+        self.assertEqual(response.data["name"], self.org1.name)
+        
+        projects = response.data["projects"]
+        project_names = [p["name"] for p in projects]
+        self.assertIn("Project 1", project_names)
+        self.assertIn("Project 2", project_names)
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_pagination(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"page_size": 1})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        for field in ["next", "previous", "results"]:
+            self.assertIn(field, response.data)
+        
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_ordering(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"ordering": "-created_at"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        results = response.data["results"]
+        if len(results) > 1:
+            created_dates = [org["created_at"] for org in results]
+            self.assertEqual(created_dates, sorted(created_dates, reverse=True))
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_vtex_account_field_handling(self):
+        self._auth_as_crm()
+        response = self.client.get(self.list_url, {"organization_uuid": str(self.org1.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        
+        org = results[0]
+        projects = org["projects"]
+        
+        project1_data = next(p for p in projects if p["name"] == "Project 1")
+        project2_data = next(p for p in projects if p["name"] == "Project 2")
+        
+        self.assertEqual(project1_data["vtex_account"], "vtex-account-1")
+        self.assertEqual(project2_data["vtex_account"], "")
+
+    @override_settings(ALLOW_CRM_ACCESS=True, CRM_EMAILS_LIST=["crmuser@user.com"])
+    def test_method_not_allowed(self):
+        self._auth_as_crm()
+        
+        response = self.client.post(self.list_url, {})
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        
+        detail_url = reverse("crm-organizations-detail", kwargs={"uuid": self.org1.uuid})
+        response = self.client.put(detail_url, {})
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        
+        response = self.client.delete(detail_url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED) 

--- a/connect/api/v2/internals/views.py
+++ b/connect/api/v2/internals/views.py
@@ -93,6 +93,9 @@ class CRMOrganizationViewSet(
 
     def get_queryset(self):
         """Apply base filters"""
+        if getattr(self, "swagger_fake_view", False):
+            return Organization.objects.none()  # pragma: no cover
+
         queryset = super().get_queryset()
 
         queryset = queryset.select_related().prefetch_related(
@@ -115,3 +118,19 @@ class CRMOrganizationViewSet(
                 ordering.append(param)
 
         return ordering or ["created_at"]
+
+    @swagger_auto_schema(
+        operation_description="List organizations for CRM users with filtering",
+        tags=["CRM Organizations"],
+    )
+    def list(self, request, *args, **kwargs):
+        """List organizations with filtering capabilities for CRM users"""
+        return super().list(request, *args, **kwargs)
+
+    @swagger_auto_schema(
+        operation_description="Retrieve specific organization details",
+        tags=["CRM Organizations"],
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """Retrieve a specific organization by UUID"""
+        return super().retrieve(request, *args, **kwargs)

--- a/connect/api/v2/routers.py
+++ b/connect/api/v2/routers.py
@@ -56,6 +56,12 @@ router.register(
     "organizations", organization_views.OrganizationViewSet, basename="organizations"
 )
 
+router.register(
+    r"internal/organizations",
+    connect_internal_views.CRMOrganizationViewSet,
+    basename="crm-organizations",
+)
+
 projects_router = routers.NestedSimpleRouter(
     router, r"organizations", lookup="organization"
 )

--- a/connect/common/helpers.py
+++ b/connect/common/helpers.py
@@ -29,7 +29,9 @@ def send_mass_html_mail(
         headers["X-SMTPAPI"] = json.dumps({"asm_group_id": int(unsubscribe_group_id)})
 
     for subject, text, html, from_email, recipient in datatuple:
-        message = EmailMultiAlternatives(subject, text, from_email, recipient, headers=headers)
+        message = EmailMultiAlternatives(
+            subject, text, from_email, recipient, headers=headers
+        )
         message.attach_alternative(html, "text/html")
         messages.append(message)
     return connection.send_messages(messages)

--- a/connect/common/models.py
+++ b/connect/common/models.py
@@ -556,7 +556,7 @@ class Project(models.Model):
         _("Project status"),
         choices=ProjectStatus.choices,
         default=ProjectStatus.ACTIVE,
-        max_length=8
+        max_length=8,
     )
 
     def __str__(self):
@@ -1532,13 +1532,13 @@ class BillingPlan(models.Model):
 
             with translation.override(language_code):
                 message = render_to_string("billing/emails/removed_card.txt", context)
-                html_message = render_to_string("billing/emails/removed_card.html", context)
+                html_message = render_to_string(
+                    "billing/emails/removed_card.html", context
+                )
             if language_code == "en-us":
                 subject = _("Attention: credit card removed from Weni Platform")
             else:
-                subject = _(
-                    "Cartão de crédito removido na Weni Plataforma"
-                )
+                subject = _("Cartão de crédito removido na Weni Plataforma")
 
             recipient_list = [user_email]
             msg = (subject, message, html_message, from_email, recipient_list)
@@ -1567,7 +1567,9 @@ class BillingPlan(models.Model):
                 html_message = render_to_string(
                     "billing/emails/free-plan-expired.html", context
                 )
-                message = render_to_string("billing/emails/free-plan-expired.txt", context)
+                message = render_to_string(
+                    "billing/emails/free-plan-expired.txt", context
+                )
 
             if language_code == "en-us":
                 subject = _("Your Free Plan on Weni has expired")

--- a/connect/common/utils.py
+++ b/connect/common/utils.py
@@ -20,7 +20,9 @@ def send_email(subject, to, template_txt, template_html=None, context=None):
     unsubscribe_group_id = getattr(settings, "SENDGRID_UNSUBSCRIBE_GROUP_ID", None)
     headers = {}
     if unsubscribe_group_id:
-        headers["X-SMTPAPI"] = json.dumps({"asm": {"group_id": int(unsubscribe_group_id)}})
+        headers["X-SMTPAPI"] = json.dumps(
+            {"asm": {"group_id": int(unsubscribe_group_id)}}
+        )
 
     if not isinstance(to, list):
         to = [to]


### PR DESCRIPTION
# 🚀 feat: Add CRM Organizations API endpoint

## 📋 Description

Implements a new internal API endpoint `/v2/internal/organizations/` that allows CRM users to retrieve detailed organization information with comprehensive filtering capabilities. This endpoint is designed for internal company use by CRM team members.