### PR TITLE
Refactor trial extension logic in BillingPlan model

### DIFF
--- a/connect/common/admin.py
+++ b/connect/common/admin.py
@@ -40,12 +40,6 @@ class BillingPlanAdminForm(forms.ModelForm):
                 raise forms.ValidationError(
                     "Trial end date is not set for this organization."
                 )
-            import pendulum
-
-            if pendulum.now() <= pendulum.instance(self.instance.trial_end_date):
-                raise forms.ValidationError(
-                    "Trial extension can only be enabled after the first trial ends."
-                )
 
         return cleaned_data
 

--- a/connect/common/models.py
+++ b/connect/common/models.py
@@ -1728,7 +1728,12 @@ class BillingPlan(models.Model):
         """
 
         self.trial_extension_enabled = True
-        self.trial_extension_end_date = pendulum.now().end_of("day").add(months=1)
+        trial_end_date = pendulum.instance(self.trial_end_date)
+        if trial_end_date > pendulum.now():
+            self.trial_extension_end_date = trial_end_date.add(months=1)
+        else:
+            self.trial_extension_end_date = pendulum.now().end_of("day").add(months=1)
+
         self.is_active = True
         self.save(
             update_fields=[


### PR DESCRIPTION
remove redundant validation in BillingPlanAdminForm. The trial extension end date is now set based on the current date and the trial end date.