### PR TITLE
refactor: Replace `ModuleHasPermission` with JWT-based `WeniAuthentication` for `OrgsByUserView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.56.1
+  - refactor: Replace ModuleHasPermission with JWT-based WeniAuthentication for OrgsByUserView
+
 # 3.56.0
   - feat: Add JWT auth and project_uuid to VTEX account authorization
 

--- a/connect/api/v2/organizations/tests.py
+++ b/connect/api/v2/organizations/tests.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock, patch
 
 from connect.api.v1.tests.utils import create_user_and_token
 from connect.api.v2.auth.tests import JWT_PUBLIC_KEY, build_weni_jwt
-from connect.authentication.models import User, UserEmailSetup
+from connect.authentication.models import UserEmailSetup
 from connect.common.models import (
     BillingPlan,
     Organization,

--- a/connect/api/v2/organizations/tests.py
+++ b/connect/api/v2/organizations/tests.py
@@ -10,8 +10,6 @@ from rest_framework.test import (
     force_authenticate,
 )
 
-from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.crypto import get_random_string
@@ -19,6 +17,7 @@ from django.utils.crypto import get_random_string
 from unittest.mock import Mock, patch
 
 from connect.api.v1.tests.utils import create_user_and_token
+from connect.api.v2.auth.tests import JWT_PUBLIC_KEY, build_weni_jwt
 from connect.authentication.models import User, UserEmailSetup
 from connect.common.models import (
     BillingPlan,
@@ -553,23 +552,27 @@ class ListOrgsByUserUseCaseTestCase(OrgsByUserBaseTestCase):
         self.assertEqual(result, [])
 
 
+@override_settings(JWT_PUBLIC_KEY=JWT_PUBLIC_KEY)
 class OrgsByUserViewTestCase(OrgsByUserBaseTestCase):
     def setUp(self):
         super().setUp()
         self.client = APIClient()
-
-        content_type = ContentType.objects.get_for_model(User)
-        permission, _ = Permission.objects.get_or_create(
-            codename="can_communicate_internally",
-            name="can communicate internally",
-            content_type=content_type,
-        )
-        self.member.user_permissions.add(permission)
-        self.client.force_authenticate(user=self.member)
         self.url = reverse("orgs-by-user")
 
+    def _token(self, **claims):
+        payload = {
+            "vtex_account": "mystore",
+            "user_email": self.member.email,
+        }
+        payload.update(claims)
+        return build_weni_jwt(**payload)
+
+    def _get(self, token=None, **query):
+        headers = {"HTTP_X_WENI_AUTH": token} if token is not None else {}
+        return self.client.get(self.url, query, **headers)
+
     def test_returns_200_with_organizations(self):
-        response = self.client.get(self.url, {"user_email": self.member.email})
+        response = self._get(token=self._token())
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["organizations"]), 1)
@@ -578,17 +581,33 @@ class OrgsByUserViewTestCase(OrgsByUserBaseTestCase):
             str(self.organization.uuid),
         )
 
-    def test_missing_user_email_returns_400(self):
-        response = self.client.get(self.url)
+    def test_missing_user_email_claim_returns_400(self):
+        token = build_weni_jwt(vtex_account="mystore")
+        response = self._get(token=token)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_unauthenticated_request_returns_403(self):
-        unauth_client = APIClient()
-        no_perm, _ = create_user_and_token("orgnoperm")
-        unauth_client.force_authenticate(user=no_perm)
+    def test_missing_token_returns_401(self):
+        response = self._get()
 
-        response = unauth_client.get(self.url, {"user_email": self.member.email})
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_query_param_user_email_is_ignored(self):
+        token = self._token(user_email=self.member.email)
+        response = self._get(token=token, user_email=self.other.email)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["organizations"]), 1)
+        self.assertEqual(
+            response.data["organizations"][0]["uuid"],
+            str(self.organization.uuid),
+        )
+
+    def test_jwt_without_tenant_claim_returns_401(self):
+        token = build_weni_jwt(user_email=self.member.email)
+        response = self._get(token=token)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class OrganizationAuthorizationViewSetTestCase(TestCase):

--- a/connect/api/v2/organizations/views.py
+++ b/connect/api/v2/organizations/views.py
@@ -15,7 +15,8 @@ from connect.common.models import (
     OrganizationRole,
     BillingPlan,
 )
-from connect.api.v1.internal.permissions import ModuleHasPermission
+from weni_commons.auth import WeniAuthViewMixin
+
 from connect.api.v1.organization.permissions import (
     Has2FA,
     HasSSOAccess,
@@ -23,6 +24,7 @@ from connect.api.v1.organization.permissions import (
     IsCRMUser,
     _is_orm_user,
 )
+from connect.middleware import WeniAuthentication
 from connect.usecases.organizations.sso_access import (
     enrich_serializer_context_with_sso_access,
 )
@@ -198,20 +200,21 @@ class OrganizationAuthorizationViewSet(
         return NestedAuthorizationOrganizationSerializer
 
 
-class OrgsByUserView(views.APIView):
-    """Lists the organizations a user belongs to (by email), including each
+class OrgsByUserView(WeniAuthViewMixin, views.APIView):
+    """Lists the organizations a user belongs to, including each
     organization's projects and active member count.
 
-    Service-to-service endpoint guarded by ``ModuleHasPermission``.
+    Identity comes from the signed ``X-Weni-Auth`` JWT (``user_email`` claim),
+    never from query params — same trust boundary as other App IO routes.
     """
 
-    permission_classes = [ModuleHasPermission]
+    authentication_classes = [WeniAuthentication]
 
     def get(self, request):
-        user_email = request.query_params.get("user_email")
+        user_email = self.auth.user_email
         if not user_email:
             raise ValidationError(
-                {"user_email": _("This query parameter is required.")}
+                {"user_email": _("This claim is required in the auth token.")}
             )
 
         organizations = ListOrgsByUserUseCase().execute(user_email)


### PR DESCRIPTION
- Updated `OrgsByUserView` to inherit from `WeniAuthViewMixin` and use `WeniAuthentication`, replacing the previous `ModuleHasPermission` service-to-service permission model.
- The `user_email` identity is now extracted exclusively from the signed `X-Weni-Auth` JWT (`user_email` claim) rather than from query parameters, preventing untrusted client input from influencing the lookup.
- A `vtex_account` (tenant) claim is now required in the JWT; requests missing it return `401`.
- Requests without a token now return `401` instead of `403`, and passing `user_email` as a query param is explicitly ignored when a valid token is present.
- Updated test cases to build and pass JWTs using `build_weni_jwt`, covering missing `user_email` claim, missing token, ignored query params, and missing tenant claim scenarios.