### PR TITLE
fix: Filter orgs-by-user to linkable projects only

### DIFF
--- a/connect/api/v2/organizations/tests.py
+++ b/connect/api/v2/organizations/tests.py
@@ -503,6 +503,21 @@ class OrgsByUserBaseTestCase(APITestCase):
 
 
 class ListOrgsByUserUseCaseTestCase(OrgsByUserBaseTestCase):
+    def _create_project(self, name, *, vtex_account=None, organization=None):
+        return Project.objects.create(
+            name=name,
+            organization=organization or self.organization,
+            flow_organization=uuid.uuid4(),
+            project_type=TypeProject.COMMERCE,
+            vtex_account=vtex_account,
+        )
+
+    def _project_payload(self, project):
+        return {"uuid": str(project.uuid), "name": project.name}
+
+    def _projects_for_member(self):
+        return ListOrgsByUserUseCase().execute(self.member.email)[0]["projects"]
+
     def test_returns_orgs_with_projects_and_member_count(self):
         result = ListOrgsByUserUseCase().execute(self.member.email)
 
@@ -531,6 +546,61 @@ class ListOrgsByUserUseCaseTestCase(OrgsByUserBaseTestCase):
     def test_returns_empty_for_unknown_user(self):
         result = ListOrgsByUserUseCase().execute("missing@user.com")
         self.assertEqual(result, [])
+
+    def test_excludes_projects_with_vtex_account(self):
+        self._create_project(name="linked-project", vtex_account="mystore")
+
+        projects = self._projects_for_member()
+
+        self.assertEqual(projects, [self._project_payload(self.project)])
+
+    def test_includes_projects_with_blank_vtex_account(self):
+        self.project.vtex_account = ""
+        self.project.save(update_fields=["vtex_account"])
+
+        projects = self._projects_for_member()
+
+        self.assertEqual(projects, [self._project_payload(self.project)])
+
+    def test_includes_projects_with_null_vtex_account(self):
+        linkable = self._create_project(name="null-vtex-project", vtex_account=None)
+        self._create_project(name="linked-project", vtex_account="mystore")
+
+        projects = self._projects_for_member()
+
+        self.assertCountEqual(
+            projects,
+            [
+                self._project_payload(self.project),
+                self._project_payload(linkable),
+            ],
+        )
+
+    def test_returns_empty_projects_when_all_projects_are_linked(self):
+        self.project.vtex_account = "existing-store"
+        self.project.save(update_fields=["vtex_account"])
+        self._create_project(name="another-linked-project", vtex_account="other-store")
+
+        projects = self._projects_for_member()
+
+        self.assertEqual(projects, [])
+
+    def test_filters_mixed_linkable_and_linked_projects(self):
+        linkable_alpha = self._create_project(name="alpha-project")
+        linkable_beta = self._create_project(name="beta-project", vtex_account="")
+        self._create_project(name="linked-alpha", vtex_account="store-alpha")
+        self._create_project(name="linked-beta", vtex_account="store-beta")
+
+        projects = self._projects_for_member()
+
+        self.assertCountEqual(
+            projects,
+            [
+                self._project_payload(self.project),
+                self._project_payload(linkable_alpha),
+                self._project_payload(linkable_beta),
+            ],
+        )
 
     @patch("connect.billing.get_gateway")
     def test_returns_empty_when_only_not_setted_role(self, mock_gateway):
@@ -579,6 +649,23 @@ class OrgsByUserViewTestCase(OrgsByUserBaseTestCase):
         self.assertEqual(
             response.data["organizations"][0]["uuid"],
             str(self.organization.uuid),
+        )
+
+    def test_excludes_projects_with_vtex_account_from_response(self):
+        Project.objects.create(
+            name="linked-project",
+            organization=self.organization,
+            flow_organization=uuid.uuid4(),
+            project_type=TypeProject.COMMERCE,
+            vtex_account="mystore",
+        )
+
+        response = self._get(token=self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data["organizations"][0]["projects"],
+            [{"uuid": str(self.project.uuid), "name": "member-project"}],
         )
 
     def test_missing_user_email_claim_returns_400(self):

--- a/connect/api/v2/organizations/views.py
+++ b/connect/api/v2/organizations/views.py
@@ -201,8 +201,11 @@ class OrganizationAuthorizationViewSet(
 
 
 class OrgsByUserView(WeniAuthViewMixin, views.APIView):
-    """Lists the organizations a user belongs to, including each
-    organization's projects and active member count.
+    """Lists the organizations a user belongs to, including projects eligible
+    for VTEX account linking and each organization's active member count.
+
+    Only projects without a ``vtex_account`` are returned so consumers can
+    present options that will not fail on link.
 
     Identity comes from the signed ``X-Weni-Auth`` JWT (``user_email`` claim),
     never from query params — same trust boundary as other App IO routes.

--- a/connect/usecases/organizations/list_by_user.py
+++ b/connect/usecases/organizations/list_by_user.py
@@ -1,20 +1,25 @@
 from typing import List
 
 from django.contrib.auth import get_user_model
-from django.db.models import Count, Q
+from django.db.models import Count, Prefetch, Q
 
 from connect.common.models import (
     Organization,
     OrganizationAuthorization,
     OrganizationRole,
+    Project,
 )
 
 User = get_user_model()
 
 
 class ListOrgsByUserUseCase:
-    """Lists the organizations a user belongs to, including their projects
-    and the active member count of each organization.
+    """Lists the organizations a user belongs to, including projects that
+    are eligible for VTEX account linking, and the active member count of
+    each organization.
+
+    Only projects without a ``vtex_account`` are returned so consumers can
+    present a list where every option can be linked without error.
 
     The lookup is performed by email so it can be consumed by internal
     services that only hold the user's email.
@@ -33,9 +38,14 @@ class ListOrgsByUserUseCase:
             .exclude(role__in=self._EXCLUDED_ROLES)
             .values_list("organization", flat=True)
         )
+        linkable_projects = Project.objects.filter(
+            Q(vtex_account__isnull=True) | Q(vtex_account="")
+        )
         organizations = (
             Organization.objects.filter(pk__in=organization_ids)
-            .prefetch_related("project")
+            .prefetch_related(
+                Prefetch("project", queryset=linkable_projects),
+            )
             .annotate(
                 member_count=Count(
                     "authorizations",


### PR DESCRIPTION
## What

Updates `GET /v2/orgs-by-user` so each organization's `projects` list includes
only projects without a `vtex_account` (`null` or empty string). The filter is
applied in `ListOrgsByUserUseCase` via a `Prefetch` on the project queryset.

Adds unit tests for mixed project sets (linked vs linkable), blank/null
`vtex_account`, all-linked orgs returning `projects: []`, and an API-level
assertion on the view response. Aligns `OrgsByUserView` docstring with the new
behavior.

## Why

When linking a VTEX account, selecting a project that already has a
`vtex_account` fails with a 400 from `POST
/v2/commerce/projects/<uuid>/link-vtex-account/`. Filtering at listing time
prevents users from choosing invalid options.
