### PR TITLE
chore: Remove coverage status check from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,3 @@ jobs:
           fail_ci_if_error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check coverage status
-        run: |
-          poetry run python contrib/compare_coverage.py


### PR DESCRIPTION
This CI step is always failing due to some bug, since we have Codecov integration that already adds a CI check for the coverage in our PRs we can safely remove this step from here and avoid having failing CIs due to the bug.